### PR TITLE
Integrate code to title or hide references section.

### DIFF
--- a/src/Text/CSL/Pandoc.hs
+++ b/src/Text/CSL/Pandoc.hs
@@ -45,13 +45,14 @@ processCites style refs doc =
       (bs, lastb) = case reverse b of
                          x@(Header _ _ _) : xs -> (reverse xs, [x])
                          _                     -> (b,  [])
-      refHeader = case isRefRemove m of
+      refHeader = case hdrInlines of
+        Just ils -> lastb ++ [Header 1 ("bibliography", ["unnumbered"], []) ils]
+        _        -> lastb
+      refDiv    = case isRefRemove m of
         True  -> []
-        False -> case hdrInlines of
-          Just ils -> lastb ++ [Header 1 ("bibliography", ["unnumbered"], []) ils]
-          _  -> lastb
+        False -> [Div ("",["references"],[]) (refHeader ++ biblioList)]
   in  Pandoc m $ bottomUp (concatMap removeNocaseSpans)
-               $ bs ++ [Div ("",["references"],[]) (refHeader ++ biblioList)]
+               $ bs ++ refDiv
 
 refTitle :: Meta -> Maybe [Inline]
 refTitle meta =


### PR DESCRIPTION
This automatically adds a title to the reference section pandoc-citeproc
produces. It takes `reference-section-title` metadata as the reference section
title. If this metadata field is not specified, there is no automatic header.
So existing documents will continue to work as they always have.

It can also take a boolean metadtata `remove-ref-section` to remove the
reference section altogether. This can be useful for situations when you want
citations to be resolved, but don't want an extra few pages of references at
the end of the document.