### PR TITLE
Don’t add space after particles ending with "-"

### DIFF
--- a/src/Text/CSL/Eval/Names.hs
+++ b/src/Text/CSL/Eval/Names.hs
@@ -378,6 +378,7 @@ s  <+> Formatted [] = s
 Formatted xs <+> Formatted ys =
   case lastInline xs of
        "’"  -> Formatted (xs ++ ys)
+       "-"  -> Formatted (xs ++ ys)
        _    -> Formatted (xs ++ [Space] ++ ys)
 
 (<++>) :: [Output] -> [Output] -> [Output]


### PR DESCRIPTION
Fixes https://github.com/jgm/pandoc-citeproc/issues/129 (does not address the missing space after “de’” as in “de’ Medici”, though – no idea how to do *that*)