### PR TITLE
mention unprinted reference

### DIFF
--- a/pandoc-citeproc.hs
+++ b/pandoc-citeproc.hs
@@ -102,7 +102,7 @@ findWarnings :: Inline -> [String]
 findWarnings (Span (_,["citeproc-not-found"],[("data-reference-id",ref)]) _) =
   ["pandoc-citeproc: reference " ++ ref ++ " not found" | ref /= "*"]
 findWarnings (Span (_,["citeproc-no-output"],_) _) =
-  ["pandoc-citeproc: reference with no printed form"]
+  ["pandoc-citeproc: reference " ++ ref ++ " has no printed form" | ref /= "*"]
 findWarnings _ = []
 
 data Option =


### PR DESCRIPTION
When writing mixed Markdown and LaTeX, and [make-ing](https://github.com/JensErat/scientific-markdown/blob/master/makefile#L23) [pandoc 1.15.0.6](https://github.com/jgm/pandoc/releases/tag/1.15.0.6) and [latexmk 4.43a](http://users.phys.psu.edu/~collins/software/latexmk-jcc/versions.html) turn it into a PDF, a misspelled TeX label is identified as: `Reference 'mispelled-label' on page X undefined on input line Y`, while a misspelled BibTex citekey is not: `pandoc-citeproc: reference with no printed form`.

Since the [`citeproc-not-found` warning mentions the missing reference](https://github.com/jgm/pandoc-citeproc/blob/master/pandoc-citeproc.hs#L102), I thought `citeproc-no-output` might benefit from it as well. The fix here is just a guess :blush: Hope it helps, at least as a bug report. Apologies if it doesn't.
