### PR TITLE
Fixed embed_data_files build on OS X

### DIFF
--- a/pandoc-citeproc.cabal
+++ b/pandoc-citeproc.cabal
@@ -113,6 +113,7 @@ library
 
     if flag(embed_data_files)
        default-extensions:    CPP
+       Build-Tools:   hsb2hs >= 0.3.1
        cpp-options:   -DEMBED_DATA_FILES
        other-modules: Text.CSL.Data.Embedded
 


### PR DESCRIPTION
Added Build-Tools:   hsb2hs >= 0.3.1 to config for embed_data_files

I encountered the problem mentioned in https://github.com/jgm/pandoc/issues/1172 where

```
Text/CSL/Data/Embedded.hs:1:1:
    File name does not match module name:
    Saw: `Main'
    Expected: `Text.CSL.Data.Embedded'
```

And I noticed that the pandoc cabal file has another flag in the `embed_data_files` section so I added that to pandoc-citeproc and everything appears to be working.

 