### PR TITLE
Fix build failure for --flags=-bibutils mode

### DIFF
--- a/pandoc-citeproc.hs
+++ b/pandoc-citeproc.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Main where
 import Text.CSL.Input.Bibutils (readBiblioString, BibFormat(..))
 import Text.CSL.Reference (Reference(refId), Literal(..))
@@ -73,6 +74,7 @@ readFormat = go . map toLower
   where go "biblatex" = Just BibLatex
         go "bib"      = Just BibLatex
         go "bibtex"   = Just Bibtex
+#ifdef USE_BIBUTILS
         go "ris"      = Just Ris
         go "endnote"  = Just Endnote
         go "enl"      = Just Endnote
@@ -85,6 +87,7 @@ readFormat = go . map toLower
         go "json"     = Just Json
         go "mods"     = Just Mods
         go "yaml"     = Just Yaml
+#endif
         go _          = Nothing
 
 

--- a/src/Text/CSL/Input/Bibutils.hs
+++ b/src/Text/CSL/Input/Bibutils.hs
@@ -62,7 +62,7 @@ readBiblioFile f
         _           -> error $ "citeproc: the format of the bibliographic database could not be recognized\n" ++
                               "using the file extension."
 #else
-        _           -> error $ "citeproc: Bibliography format not supported.\n" ++
+        _           -> error $ "citeproc: Bibliography format not supported.\n"
 #endif
 
 data BibFormat


### PR DESCRIPTION
Fails as:
  [19 of 21] Compiling Text.CSL.Input.Bibutils ( src/Text/CSL/Input/Bibutils.hs, dist/build/Text/CSL/Input/Bibutils.o )

  src/Text/CSL/Input/Bibutils.hs:68:1:
    parse error (possibly incorrect indentation or mismatched brackets)

Reported-by: Thomas Beutin
Bug: https://bugs.gentoo.org/516640
Signed-off-by: Sergei Trofimovich <siarheit@google.com>