### PR TITLE
Add missing -DUSE_BIBUTILS to Cabal build.

### DIFF
--- a/pandoc-citeproc.cabal
+++ b/pandoc-citeproc.cabal
@@ -152,6 +152,9 @@ executable pandoc-citeproc
     other-modules:    Paths_pandoc_citeproc
                       Prelude
     default-language: Haskell98
+    if flag(bibutils)
+       default-extensions: CPP
+       cpp-options:     -DUSE_BIBUTILS
 
 executable test-citeproc
   Main-Is:        test-citeproc.hs


### PR DESCRIPTION
I had to add this to make the Git repository build with Bibutils using Cabal correctly. Without this support for other than Bib* formats is not available.