### PR TITLE
Improve support for citation-label (fixes #160)

### DIFF
--- a/src/Text/CSL/Eval.hs
+++ b/src/Text/CSL/Eval.hs
@@ -291,6 +291,7 @@ getFormattedValue o as f fm s val
     | Just v <- fromValue val :: Maybe Int       = output  fm (if v == 0 then [] else show v)
     | Just v <- fromValue val :: Maybe Int       = output  fm (if v == 0 then [] else show v)
     | Just v <- fromValue val :: Maybe CNum      = if v == 0 then [] else [OCitNum (unCNum v) fm]
+    | Just v <- fromValue val :: Maybe CLabel    = if v == mempty then [] else [OCitLabel (unCLabel v) fm]
     | Just v <- fromValue val :: Maybe [RefDate] = formatDate (EvalSorting emptyCite) [] [] sortDate v
     | Just v <- fromValue val :: Maybe [Agent]   = concatMap (formatName (EvalSorting emptyCite) True f
                                                               fm nameOpts []) v

--- a/src/Text/CSL/Eval/Output.hs
+++ b/src/Text/CSL/Eval/Output.hs
@@ -122,6 +122,9 @@ formatOutput o =
       OCitNum  i       f  -> if i == 0
                                 then Formatted [Strong [Str "???"]]
                                 else formatOutput (OStr (show i) f)
+      OCitLabel s      f  -> if s == ""
+                                then Formatted [Strong [Str "???"]]
+                                else formatOutput (OStr s f)
       OName  _ os _    f  -> formatOutput (Output os f)
       OContrib _ _ os _ _ -> formatOutputList os
       OLoc     os      f  -> formatOutput (Output os f)

--- a/src/Text/CSL/Proc.hs
+++ b/src/Text/CSL/Proc.hs
@@ -123,6 +123,8 @@ citeproc ops s rs cs
          OYearSuf y citeid d f{hyperlink = "#ref-" ++ citeid}
       addLink' citeid (OCitNum n f) =
          OCitNum n f{hyperlink = "#ref-" ++ citeid}
+      addLink' citeid (OCitLabel l f) =
+         OCitLabel l f{hyperlink = "#ref-" ++ citeid}
       addLink' _ x = x
 
 -- | Given the CSL 'Style' and the list of 'Reference's sort the list

--- a/src/Text/CSL/Style.hs
+++ b/src/Text/CSL/Style.hs
@@ -652,6 +652,7 @@ data Output
     | OLabel   String             Formatting            -- ^ A label used for roles
     | ONum     Int                Formatting            -- ^ A number (used to count contributors)
     | OCitNum  Int                Formatting            -- ^ The citation number
+    | OCitLabel String            Formatting            -- ^ The citation label
     | ODate   [Output]                                  -- ^ A (possibly) ranged date
     | OYear    String    String   Formatting            -- ^ The year and the citeId
     | OYearSuf String    String   [Output]   Formatting -- ^ The year suffix, the citeId and a holder for collision data

--- a/tests/issue160.csl
+++ b/tests/issue160.csl
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-US">
+  <info>
+    <title>Issue 160 Test Style</title>
+    <id>issue-160-test</id>
+    <category citation-format="label"/>
+    <updated>2017-02-04T19:31:46+0000</updated>
+  </info>
+  <citation>
+    <layout prefix="[" suffix="]" delimiter=",">
+      <text variable="citation-label"/>
+    </layout>
+  </citation>
+  <bibliography>
+    <layout>
+      <text variable="citation-label" prefix="[" suffix="] "/>
+      <group delimiter=". " suffix=".">
+        <names variable="author">
+          <name delimiter=", " delimiter-precedes-last="always"/>
+        </names>
+        <text variable="title"/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/tests/issue160.expected.native
+++ b/tests/issue160.expected.native
@@ -1,0 +1,10 @@
+Pandoc (Meta {unMeta = fromList [("csl",MetaInlines [Str "tests/issue160.csl"]),("references",MetaList [MetaMap (fromList [("author",MetaList [MetaMap (fromList [("family",MetaInlines [Str "Doe"]),("given",MetaInlines [Str "Jane"])])]),("citation-label",MetaInlines [Str "Jane11"]),("id",MetaInlines [Str "item1"]),("issued",MetaMap (fromList [("year",MetaString "2011")])),("title",MetaInlines [Str "A",Space,Str "book"]),("type",MetaInlines [Str "book"])])])]})
+[Header 2 ("no-citation-label",[],[]) [Str "No",Space,Str "citation-label"]
+,Para [Str "Foo",Space,Cite [Citation {citationId = "item1", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 1}] [Str "[Jane11]"],Str "."]
+,Header 2 ("expected",[],[]) [Str "Expected"]
+,BlockQuote
+ [Para [Str "Foo",Space,Str "[Jane11]."]
+ ,Para [Str "[Jane11]",Space,Str "Jane",Space,Str "Doe.",Space,Str "A",Space,Str "book.",Space,Str "2011."]]
+,Div ("refs",["references"],[])
+ [Div ("ref-item1",[],[])
+  [Para [Str "[Jane11]",Space,Str "Jane",Space,Str "Doe.",Space,Str "A",Space,Str "book.",Space,Str "2011."]]]]

--- a/tests/issue160.in.native
+++ b/tests/issue160.in.native
@@ -1,0 +1,7 @@
+Pandoc (Meta {unMeta = fromList [("csl",MetaInlines [Str "tests/issue160.csl"]),("references",MetaList [MetaMap (fromList [("author",MetaList [MetaMap (fromList [("family",MetaInlines [Str "Doe"]),("given",MetaInlines [Str "Jane"])])]),("citation-label",MetaInlines [Str "Jane11"]),("id",MetaInlines [Str "item1"]),("issued",MetaMap (fromList [("year",MetaString "2011")])),("title",MetaInlines [Str "A",Space,Str "book"]),("type",MetaInlines [Str "book"])])])]})
+[Header 2 ("no-citation-label",[],[]) [Str "No",Space,Str "citation-label"]
+,Para [Str "Foo",Space,Cite [Citation {citationId = "item1", citationPrefix = [], citationSuffix = [], citationMode = NormalCitation, citationNoteNum = 0, citationHash = 0}] [Str "[@item1]"],Str "."]
+,Header 2 ("expected",[],[]) [Str "Expected"]
+,BlockQuote
+ [Para [Str "Foo",Space,Str "[Jane11]."]
+ ,Para [Str "[Jane11]",Space,Str "Jane",Space,Str "Doe.",Space,Str "A",Space,Str "book.",Space,Str "2011."]]]


### PR DESCRIPTION
I encountered #160 and tried to fix it.

The `citation-label` variable was not rendered, even when it was explicitly set in a bibliography item. This is now fixed. I added a test case to demonstrate this. My real-world problem is also resolved with this change.

But since I largely worked by cargo-cult programming, there may be some bugs in this fix. In particular, I have no idea how this interacts with collapsing. I'd be glad if someone looked over this.

My gut feeling was that one of the pattern matches during variable lookup or formatting would somehow get rid of the `citation-label`. After all, this variable was reported as empty in CSL templates even when it was set in the metadata. To distinguish the citation-label from normal string variables, I introduced `CLabel` and `OCitLabel` in analogy to `CNum` and `OCitNum`.

Additionally, inline citations with citation labels can now also be linked like citation numbers or author-year citations.