### PR TITLE
Add flag to silence all warnings

### DIFF
--- a/man/pandoc-citeproc.1.md
+++ b/man/pandoc-citeproc.1.md
@@ -202,6 +202,9 @@ by other CSL implementations.
 `--license`
 :   Print the license.
 
+`-q, --quiet`
+:   Silence all warnings.
+
 `-V, --version`
 :   Print version.
 


### PR DESCRIPTION
Introduce new command line flag `--quiet`/`-q` which can be used to
suppress all warnings.