### PR TITLE
Allow superscript in-text styles to be treated as "notes"

### DIFF
--- a/src/Text/CSL/Pandoc.hs
+++ b/src/Text/CSL/Pandoc.hs
@@ -297,6 +297,7 @@ getNoteCitationIds _        = []
 isNote :: Inline -> Bool
 isNote (Note _)          = True
 isNote (Cite _ [Note _]) = True
+isNote (Cite _ [Superscript _]) = True
 isNote _                 = False
 
 mvPunctInsideQuote :: Inline -> Inline -> [Inline]

--- a/src/Text/CSL/Pandoc.hs
+++ b/src/Text/CSL/Pandoc.hs
@@ -297,6 +297,9 @@ getNoteCitationIds _        = []
 isNote :: Inline -> Bool
 isNote (Note _)          = True
 isNote (Cite _ [Note _]) = True
+ -- the following allows citation styles that are "in-text" but use superscript
+ -- references to be treated as if they are "notes" for the purposes of moving
+ -- the citations after trailing punctuation (see <https://github.com/jgm/pandoc-citeproc/issues/382>):
 isNote (Cite _ [Superscript _]) = True
 isNote _                 = False
 


### PR DESCRIPTION
This addresses https://github.com/jgm/pandoc-citeproc/issues/382 and allows `in-text` styles that use superscript to be treated as "notes" for the purposes of moving the citations after punctuation (controlled by `notes-after-punctuation`).