### PR TITLE
Incorporate the switch to Text in the dependencies

### DIFF
--- a/compat/Text/CSL/Compat/Pandoc.hs
+++ b/compat/Text/CSL/Compat/Pandoc.hs
@@ -117,7 +117,7 @@ fetchItem :: String
           -> IO (Either E.SomeException (B.ByteString, Maybe MimeType))
 #if MIN_VERSION_pandoc(2,0,0)
 fetchItem s = do
-  res <- runIO $ runExceptT $ lift $ Text.Pandoc.Class.fetchItem s
+  res <- runIO $ runExceptT $ lift $ Text.Pandoc.Class.fetchItem $ T.pack s
   return $ case res of
        Left e          -> Left (E.toException e)
        Right (Left (e :: PandocError))  -> Left (E.toException e)

--- a/pandoc-citeproc.hs
+++ b/pandoc-citeproc.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP                 #-}
 {-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Main where
 import           Prelude
@@ -135,7 +136,7 @@ doCites beQuiet doc = do
 
 findWarnings :: Inline -> [String]
 findWarnings (Span (_,["citeproc-not-found"],[("data-reference-id",ref)]) _) =
-  ["pandoc-citeproc: reference " ++ ref ++ " not found" | ref /= "*"]
+  ["pandoc-citeproc: reference " ++ T.unpack ref ++ " not found" | ref /= "*"]
 findWarnings (Span (_,["citeproc-no-output"],_) _) =
   ["pandoc-citeproc: reference with no printed form"]
 findWarnings _ = []

--- a/src/Text/CSL/Eval/Common.hs
+++ b/src/Text/CSL/Eval/Common.hs
@@ -26,6 +26,7 @@ import           Data.Char           (toLower)
 import           Data.List           (elemIndex)
 import qualified Data.Map            as M
 import           Data.Maybe
+import qualified Data.Text           as T
 
 import           Text.CSL.Reference
 import           Text.CSL.Style
@@ -125,7 +126,7 @@ getStringValue val =
   -- but need a String.  This is currently needed for "page".  It's a bit
   -- hackish; we should probably change the type in Reference for
   -- page to String.
-  case fromValue val `mplus` ((stringify . unFormatted) `fmap` fromValue val)
+  case fromValue val `mplus` ((T.unpack . stringify . unFormatted) `fmap` fromValue val)
        `mplus` (unLiteral `fmap` fromValue val) of
        Just v   -> v
        Nothing  -> Debug.Trace.trace ("Expecting string value, got " ++

--- a/src/Text/CSL/Eval/Date.hs
+++ b/src/Text/CSL/Eval/Date.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
 -----------------------------------------------------------------------------
 -- |
@@ -23,6 +24,7 @@ import           Control.Monad.State
 import           Data.List
 import           Data.List.Split
 import           Data.Maybe (fromMaybe, isNothing)
+import qualified Data.Text              as T
 
 import           Text.CSL.Exception
 import           Text.CSL.Eval.Common
@@ -144,7 +146,7 @@ formatDate em k tm dp date
         | null (concat o1 ++ concat o2) = []
         | otherwise = o1 ++ (case dpRangeDelim <$> last' xs of
                               ["-"] -> [[OPan [Str "\x2013"]]]
-                              [s]   -> [[OPan [Str s]]]
+                              [s]   -> [[OPan [Str $ T.pack s]]]
                               _     -> []) ++ o2
 
       formatYear f y

--- a/src/Text/CSL/Input/Bibutils.hs
+++ b/src/Text/CSL/Input/Bibutils.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP                      #-}
 {-# LANGUAGE ScopedTypeVariables      #-}
 {-# LANGUAGE PatternGuards            #-}
@@ -221,7 +222,7 @@ convertRefs (Just v) =
          -- references:
          -- ...
          case fromJSON (metaValueToJSON v) of
-               Success "" -> Right []
+               Success ("" :: String) -> Right []
                _          -> Left s
        Success x            -> Right x
 

--- a/src/Text/CSL/Parser.hs
+++ b/src/Text/CSL/Parser.hs
@@ -131,7 +131,7 @@ string = unpack . T.concat . content
 
 attrWithDefault :: Read a => Text -> a -> Cursor -> a
 attrWithDefault t d cur =
-  fromMaybe d $ safeRead (toRead $ stringAttr t cur)
+  fromMaybe d $ safeRead (T.pack $ toRead $ stringAttr t cur)
 
 stringAttr :: Text -> Cursor -> String
 stringAttr t cur =

--- a/src/Text/CSL/Proc.hs
+++ b/src/Text/CSL/Proc.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE PatternGuards     #-}
+{-# LANGUAGE ViewPatterns      #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.CSL.Proc
@@ -28,6 +29,7 @@ import           Data.Char              (isDigit, isLetter, toLower)
 import           Data.List
 import           Data.Maybe             (mapMaybe)
 import           Data.Ord               (comparing)
+import qualified Data.Text              as T
 import           Text.CSL.Eval
 import           Text.CSL.Proc.Collapse
 import           Text.CSL.Proc.Disamb
@@ -340,7 +342,7 @@ formatCitLayout s (CG co f d cs)
         case ys of
              Formatted []           -> xs
              Formatted (Note _ : _) -> xs <> ys
-             Formatted (Str [c]:_)  | c `elem` (", ;:" :: String) -> xs <> ys
+             Formatted (Str (T.unpack -> [c]):_)  | c `elem` (", ;:" :: String) -> xs <> ys
              _                      -> xs <> Formatted [Space] <> ys
       formatAuth   = formatOutput . localMod
       formatCits   = (if isNote then toNote else id) .

--- a/src/Text/CSL/Proc/Collapse.hs
+++ b/src/Text/CSL/Proc/Collapse.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards     #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.CSL.Proc.Collapse
@@ -23,6 +25,7 @@ import           Data.Char
 import           Data.List              (groupBy, sortBy)
 import           Data.Monoid            (Any (..))
 import           Data.Ord               (comparing)
+import qualified Data.Text              as T
 import           Text.CSL.Eval
 import           Text.CSL.Proc.Disamb
 import           Text.CSL.Style         hiding (Any)
@@ -208,11 +211,11 @@ addCiteAffixes c x =
             Formatted  []    -> []
             Formatted ils
               | isprefix  -> case reverse ils of
-                                  (Str zs@(_:_):_) |
-                                    last zs == '\160' -> [OPan ils]
+                                  (Str zs@(T.uncons -> Just (_,_)):_) |
+                                    T.last zs == '\160' -> [OPan ils]
                                   _ -> [OPan ils, OSpace]
               | otherwise -> case ils of
-                                  (Str (z:_):_)
+                                  (Str (T.uncons -> Just (z,_)):_)
                                     | isAlphaNum z ||
                                       z == '(' -> [OSpace, OPan ils]
                                   _            -> [OPan ils]

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,18 +9,23 @@ flags:
 packages:
 - '.'
 extra-deps:
-- pandoc-types-1.17.6.1
 - HsYAML-0.2.0.0
 - HsYAML-aeson-0.2.0.0
-- texmath-0.11.3
 - haddock-library-1.8.0
 - skylighting-0.8.2.3
 - skylighting-core-0.8.2.3
 - regex-pcre-builtin-0.95.0.8.8.35
 - doctemplates-0.7
 - doclayout-0.2.0.1
-- git: https://github.com/jgm/pandoc.git
-  commit: 8f3b3afc70d163afe5e103abec77a4ffafb995bd
+  # The text branch
+- git: git@github.com:jgm/texmath
+  commit: 0d71300d91513bdd812d2c89b78460c15c277457
+  # The text branch
+- git: git@github.com:despresc/pandoc-types
+  commit: 59c45cdd996ed57c51112e3c22be4a8e2ea697a3
+  # The text branch
+- git: git@github.com:jgm/pandoc
+  commit: 37aeb807752f4e1fe97c63ba8e0354aa3935e117
 
 ghc-options:
    "$locals": -fhide-source-paths


### PR DESCRIPTION
This is a fairly minimal incorporation of the changes to the other core `pandoc` packages. Pack and unpack invocations and view patterns were used to keep the types and logic in the package the same.

The `compat` module still exists, but the inserted `pack` statement means that the module will fail to compile on a version of `pandoc` without the switch to `Text`.