### PR TITLE
Add suppress-min and suppress-max cs:name attributes

### DIFF
--- a/pandoc-citeproc.cabal
+++ b/pandoc-citeproc.cabal
@@ -116,6 +116,7 @@ library
                       aeson >= 0.7 && < 1.6,
                       text,
                       vector,
+                      transformers,
                       xml-conduit >= 1.2 && < 1.10,
                       unordered-containers >= 0.2 && < 0.3,
                       data-default,

--- a/src/Text/CSL/Parser.hs
+++ b/src/Text/CSL/Parser.hs
@@ -266,6 +266,8 @@ parseName cur =
                  n `elem` nameAttrKeys]
          nameAttrKeys =  [ "et-al-min"
                          , "et-al-use-first"
+                         , "suppress-min"
+                         , "suppress-max"
                          , "et-al-subsequent-min"
                          , "et-al-subsequent-use-first"
                          , "et-al-use-last"


### PR DESCRIPTION
This is a partial implementation of `suppress-min` and `suppress-max` `cs:name` attributes from [CSL-M extensions to CSL v1.0.1](https://citeproc-js.readthedocs.io/en/latest/csl-m/#suppress-min-extension).

Special handling of `suppress-min=0` is not implemented (it is predicated on `cs:institution` extension, which isn't implemented)

I realize this addition might be somewhat questionable, due to not being a part of main CSL spec, but it's required to implement rule 7.5.1 from GOST R 7.0.5-2008, which requires different author block placement and formatting depending on the number of authors.

I could probably invent a simpler extension to handle this particular case, but I think that would be even worse.

I've added `transformers` to dependencies for the sake of `MaybeT`. I don't think it's an issue, since as far as I can tell, pandoc-citeproc transiently depends on it anyway. Without `MaybeT` the patch would be a lot less concise.